### PR TITLE
Lock address for non master wallets

### DIFF
--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -114,6 +114,7 @@ export class CurrencyEngine {
   feeTimer: any
   fees: BitcoinFees
   otherMethods: Object
+  masterWalletIds: Object
 
   // ------------------------------------------------------------------------
   // Private API
@@ -130,6 +131,12 @@ export class CurrencyEngine {
     const test: EdgeCurrencyEngine = this
     this.walletInfo = walletInfo
     this.walletId = walletInfo.id || ''
+    // masterWalletIds should look like this
+    // {
+    //   btc: master-ember-btc-edge-wallet-id
+    //   ltc: master-ember-ltc-edge-wallet-id
+    // }
+    this.masterWalletIds = {}
     this.prunedWalletId = this.walletId.slice(0, 6)
     this.pluginState = pluginState
     this.callbacks = options.callbacks
@@ -378,12 +385,24 @@ export class CurrencyEngine {
     logger.info(`${this.prunedWalletId}: ${log}`)
   }
 
+
+  isEmberMasterWallet(): boolean {
+    if (this.network === 'bitcoin' && this.masterWalletIds) {
+      return this.masterWalletIds.btc === this.walletId
+    }
+    return false
+  }
+
   // ------------------------------------------------------------------------
   // Public API
   // ------------------------------------------------------------------------
 
   async changeUserSettings (userSettings: Object): Promise<mixed> {
-    await this.pluginState.updateServers(userSettings)
+    if (userSettings && userSettings.masterWalletIds) {
+      this.masterWalletIds = userSettings.masterWalletIds
+    } else {
+      await this.pluginState.updateServers(userSettings)
+    }
   }
 
   async startEngine (): Promise<void> {
@@ -455,7 +474,9 @@ export class CurrencyEngine {
   }
 
   getFreshAddress (options: any): EdgeFreshAddress {
-    const publicAddress = this.keyManager.getReceiveAddress()
+    // Let's give a fresh address if we do not have Ember master wallet ids infos or we do and
+    // the engine refers to an Ember master wallet
+    const publicAddress = this.keyManager.getReceiveAddress(!Object.keys(this.masterWalletIds).length || this.isEmberMasterWallet())
     const legacyAddress = toLegacyFormat(publicAddress, this.network)
     return { publicAddress, legacyAddress }
   }
@@ -600,6 +621,7 @@ export class CurrencyEngine {
         utxos,
         rate,
         txOptions,
+        isMasterWallet: this.isEmberMasterWallet(),
         height: this.getBlockHeight()
       })
 

--- a/src/engine/keyManager.js
+++ b/src/engine/keyManager.js
@@ -59,7 +59,8 @@ export type createTxOptions = {
   utxos: Array<Utxo>,
   height: BlockHeight,
   rate: number,
-  txOptions: TxOptions
+  txOptions: TxOptions,
+  isMasterWallet?: boolean
 }
 
 export type SignMessage = {
@@ -207,13 +208,19 @@ export class KeyManager {
     await this.load()
   }
 
-  getReceiveAddress (): string {
-    return this.getNextAvailable(this.keys.receive.children)
+  getReceiveAddress (giveFreshAddress: boolean = true): string {
+    if (giveFreshAddress) {
+        return this.getNextAvailable(this.keys.receive.children)
+    }
+    return this.keys.receive.children[0].displayAddress
   }
 
-  getChangeAddress (): string {
+  getChangeAddress (giveFreshAddress: boolean = true): string {
     if (this.bip === 'bip32') return this.getReceiveAddress()
-    return this.getNextAvailable(this.keys.change.children)
+    if (giveFreshAddress) {
+      return this.getNextAvailable(this.keys.change.children)
+    }
+    return this.keys.change.children[0].displayAddress
   }
 
   async createTX (options: createTxOptions): any {
@@ -250,7 +257,7 @@ export class KeyManager {
     return createTX({
       ...rest,
       outputs: standardOutputs,
-      changeAddress: this.getChangeAddress(),
+      changeAddress: this.getChangeAddress(options.isMasterWallet),
       estimate: prev => this.fSelector.estimateSize(prev),
       network: this.network
     })


### PR DESCRIPTION
This allows us to lock receive and change addresses for all non-master wallets within Edge.
We should all test if it doesn't fuck things up as I have only tested with Bitcoin so far.  